### PR TITLE
Add config-driven custom tokenizer support

### DIFF
--- a/Config.yml
+++ b/Config.yml
@@ -8,6 +8,8 @@ compute_dtype: float16
 tokenizer_name: EleutherAI/gpt-neo-125M
 tokenizer_path: tiny_cached
 tokenizer_dtype: uint16
+use_custom_tokenizer: false
+custom_tokenizer_path: math_tokenizer_data
 
 # DATASET_VENDOR = "Salesforce/wikitext"
 # DATASET_NAME   = "wikitext-2-raw-v1"
@@ -18,6 +20,7 @@ dataset_vendor: Salesforce
 # dataset_has_vendor: false
 # dataset_vendor: roneneldan
 use_custom_dataset: true
+dataset_path: math_dataset_arrow
 
 
 # model:

--- a/Run_training.py
+++ b/Run_training.py
@@ -18,7 +18,6 @@ from omegaconf import OmegaConf
 Config = OmegaConf.load("Config.yml")
 
 import jax.numpy as jnp
-from transformers import AutoTokenizer
 
 from GiantGPT import GiantGPT
 from Training_step    import train_step
@@ -51,7 +50,7 @@ def main():
 
     model = GiantGPT(
         # vocab_size = Config.vocab_size,
-        vocab_size = AutoTokenizer.from_pretrained(Config.tokenizer_name).vocab_size,
+        vocab_size = tokenizer.vocab_size,
         context_length    = Config.context_length,
         d_model    = Config.embedding_size,
         n_heads    = Config.num_heads,

--- a/prepare_dataset.py
+++ b/prepare_dataset.py
@@ -34,7 +34,7 @@ from typing import List, Tuple
 
 import numpy as np
 from datasets import load_dataset
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, PreTrainedTokenizerFast
 from tqdm.auto import tqdm
 
 from omegaconf import OmegaConf
@@ -64,7 +64,12 @@ PAD_FRAC_LIMIT  = 0.05        # sanity‑check threshold
 # Tokeniser & pad‑token handling
 # ────────────────────────────────
 print("▶ Loading tokenizer …")
-_tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_NAME)
+if Config.use_custom_tokenizer:
+    _tokenizer = PreTrainedTokenizerFast.from_pretrained(
+        Config.custom_tokenizer_path
+    )
+else:
+    _tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_NAME)
 if _tokenizer.pad_token is None:
     _tokenizer.add_special_tokens({"pad_token": "<|pad|>"})
 PAD_TOKEN_ID = _tokenizer.pad_token_id

--- a/prepare_my_dataset.py
+++ b/prepare_my_dataset.py
@@ -34,7 +34,7 @@ from typing import List, Tuple
 
 import numpy as np
 from datasets import load_dataset
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, PreTrainedTokenizerFast
 from tqdm.auto import tqdm
 
 from omegaconf import OmegaConf
@@ -67,7 +67,12 @@ from datasets import load_from_disk
 DATA_PATH = Path(Config.dataset_path or "math_dataset_arrow")
 print(f"▶ Loading math dataset from {DATA_PATH} …")
 ds_main = load_from_disk(str(DATA_PATH))
-_tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_NAME)
+if Config.use_custom_tokenizer:
+    _tokenizer = PreTrainedTokenizerFast.from_pretrained(
+        Config.custom_tokenizer_path
+    )
+else:
+    _tokenizer = AutoTokenizer.from_pretrained(TOKENIZER_NAME)
 if _tokenizer.pad_token is None:
     _tokenizer.add_special_tokens({"pad_token": "<|pad|>"})
 PAD_TOKEN_ID = _tokenizer.pad_token_id


### PR DESCRIPTION
## Summary
- allow specifying a custom tokenizer and dataset path in `Config.yml`
- load tokenizer conditionally in dataset prep, training, and generation scripts
- use tokenizer returned by dataset loader to set model vocab size

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v test_jax.py)`

------
https://chatgpt.com/codex/tasks/task_e_6857cad537988326bbe5a90af3552492